### PR TITLE
chore(ci): dependabot with code owners file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,3 @@ updates:
           - "minor"
           - "patch"
     open-pull-requests-limit: 1
-    reviewers:
-      - "AtomicFS"
-    assignees:
-      - "AtomicFS"


### PR DESCRIPTION
- reviewers field in the dependabot.yml is about to be removed
- code owners file should be used instead
- https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/